### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,35 @@
+name: build-docker-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag for Docker image'
+        required: true
+      ref:
+        description: 'Branch, tag, or commit SHA to build from'
+        required: true
+        default: main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3.1.1
+        with:
+          context: .
+          push: true
+          tags: octue/get-deployment-info:${{ github.event.inputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install poetry
+        uses: snok/install-poetry@v1.3.3
+
       - name: Get package version
         id: get-package-version
         run: echo "PACKAGE_VERSION=$(poetry version -s)" >> $GITHUB_OUTPUT

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,9 @@
 name: test-deployment-info
 
 on:
-  push:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   info:
@@ -23,10 +25,10 @@ jobs:
         id: get-deployment-info
         uses: ./
         with:
-          gcp_project_name: test-project
+          gcp_project_name: my-test-project
           gcp_project_number: 1234
-          gcp_region: europe-west1
-          gcp_resource_affix: test
+          gcp_region: europe-west6
+          gcp_resource_affix: my-affix
           gcp_service_name: my-test-service
           gcp_environment: main
 
@@ -47,3 +49,8 @@ jobs:
           echo ${{ steps.get-deployment-info.outputs.gcp_resource_affix }}
           echo ${{ steps.get-deployment-info.outputs.gcp_service_name }}
           echo ${{ steps.get-deployment-info.outputs.version }}
+
+      - uses: nick-fields/assert-action@v1
+        with:
+          expected: europe-west6-docker.pkg.dev/my-test-project/my-affix/my-test-service:-latest
+          actual: ${{ steps.get-deployment-info.outputs.image_latest_artefact }}

--- a/action.yaml
+++ b/action.yaml
@@ -35,7 +35,7 @@ outputs:
   image_latest_tag:
     description: "The tag of the latest docker image."
   image_version_artefact:
-    description:  "The artefact URI for the docker image for the version to deploy."
+    description: "The artefact URI for the docker image for the version to deploy."
   image_version_tag:
     description: "The tag of the docker image for the version."
   short_sha:


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#2](https://github.com/octue/get-deployment-info/pull/2))

### Operations
- Add missing `poetry` installation step in release workflow
- Add workflow for manually building/pushing docker images

### Testing
- Add assertion to workflow

### Chores
- Remove extra space

<!--- END AUTOGENERATED NOTES --->