### PR TITLE
Rename "artefact" to "artifact" to align with common spelling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,11 +46,11 @@ jobs:
           expected: ${{ env.GITHUB_REF_SLUG }}
           actual: ${{ steps.get-deployment-info.outputs.branch_tag_kebab }}
 
-      - name: Check `image_latest_artefact`
+      - name: Check `image_latest_artifact`
         uses: nick-fields/assert-action@v1
         with:
           expected: europe-west6-docker.pkg.dev/my-test-project/my-affix/my-test-service:${{ env.GITHUB_REF_SLUG }}-latest
-          actual: ${{ steps.get-deployment-info.outputs.image_latest_artefact }}
+          actual: ${{ steps.get-deployment-info.outputs.image_latest_artifact }}
 
       - name: Check `image_latest_tag`
         uses: nick-fields/assert-action@v1
@@ -58,11 +58,11 @@ jobs:
           expected: ${{ env.GITHUB_REF_SLUG }}-latest
           actual: ${{ steps.get-deployment-info.outputs.image_latest_tag }}
 
-      - name: Check `image_version_artefact`
+      - name: Check `image_version_artifact`
         uses: nick-fields/assert-action@v1
         with:
           expected: europe-west6-docker.pkg.dev/my-test-project/my-affix/my-test-service:${{ env.GITHUB_REF_SLUG }}-unreleased
-          actual: ${{ steps.get-deployment-info.outputs.image_version_artefact }}
+          actual: ${{ steps.get-deployment-info.outputs.image_version_artifact }}
 
       - name: Check `image_version_tag`
         uses: nick-fields/assert-action@v1

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Outputs can be accessed in the usual way. For example, to print all the outputs:
   run: |
     echo ${{ steps.get-deployment-info.outputs.branch_tag_kebab }}
     echo ${{ steps.get-deployment-info.outputs.branch_tag_screaming }}
-    echo ${{ steps.get-deployment-info.outputs.image_latest_artefact }}
+    echo ${{ steps.get-deployment-info.outputs.image_latest_artifact }}
     echo ${{ steps.get-deployment-info.outputs.image_latest_tag }}
-    echo ${{ steps.get-deployment-info.outputs.image_version_artefact }}
+    echo ${{ steps.get-deployment-info.outputs.image_version_artifact }}
     echo ${{ steps.get-deployment-info.outputs.image_version_tag }}
     echo ${{ steps.get-deployment-info.outputs.short_sha }}
     echo ${{ steps.get-deployment-info.outputs.version_slug }}

--- a/action.yaml
+++ b/action.yaml
@@ -30,12 +30,12 @@ outputs:
     description: "The tag or branch name in kebab case."
   branch_tag_screaming:
     description: "The tag or branch name in screaming snake case."
-  image_latest_artefact:
-    description: "The artefact URI for the latest docker image."
+  image_latest_artifact:
+    description: "The artifact URI for the latest docker image."
   image_latest_tag:
     description: "The tag of the latest docker image."
-  image_version_artefact:
-    description: "The artefact URI for the docker image for the version to deploy."
+  image_version_artifact:
+    description: "The artifact URI for the docker image for the version to deploy."
   image_version_tag:
     description: "The tag of the docker image for the version."
   short_sha:

--- a/get_deployment_info/entrypoint.sh
+++ b/get_deployment_info/entrypoint.sh
@@ -48,12 +48,12 @@ echo "image_version_tag=$IMAGE_VERSION_TAG" >> $GITHUB_OUTPUT
 IMAGE_LATEST_TAG="$BRANCH_TAG_KEBAB-latest"
 echo "image_latest_tag=$IMAGE_LATEST_TAG" >> $GITHUB_OUTPUT
 
-# Set image artefact addresses.
-IMAGE_VERSION_ARTEFACT="$GCP_REGION-docker.pkg.dev/$GCP_PROJECT_NAME/$GCP_RESOURCE_AFFIX/$GCP_SERVICE_NAME:$IMAGE_VERSION_TAG"
-echo "image_version_artefact=$IMAGE_VERSION_ARTEFACT" >> $GITHUB_OUTPUT
+# Set image artifact addresses.
+IMAGE_VERSION_ARTIFACT="$GCP_REGION-docker.pkg.dev/$GCP_PROJECT_NAME/$GCP_RESOURCE_AFFIX/$GCP_SERVICE_NAME:$IMAGE_VERSION_TAG"
+echo "image_version_artifact=$IMAGE_VERSION_ARTIFACT" >> $GITHUB_OUTPUT
 
-IMAGE_LATEST_ARTEFACT="$GCP_REGION-docker.pkg.dev/$GCP_PROJECT_NAME/$GCP_RESOURCE_AFFIX/$GCP_SERVICE_NAME:$IMAGE_LATEST_TAG"
-echo "image_latest_artefact=$IMAGE_LATEST_ARTEFACT" >> $GITHUB_OUTPUT
+IMAGE_LATEST_ARTIFACT="$GCP_REGION-docker.pkg.dev/$GCP_PROJECT_NAME/$GCP_RESOURCE_AFFIX/$GCP_SERVICE_NAME:$IMAGE_LATEST_TAG"
+echo "image_latest_artifact=$IMAGE_LATEST_ARTIFACT" >> $GITHUB_OUTPUT
 
 # Echo the outputs to stdout to aid debugging.
 echo ""
@@ -61,9 +61,9 @@ echo "OUTPUTS"
 echo "======="
 echo "- branch_tag_kebab: $BRANCH_TAG_KEBAB"
 echo "- branch_tag_screaming: $BRANCH_TAG_SCREAMING"
-echo "- image_latest_artefact: $IMAGE_LATEST_ARTEFACT"
+echo "- image_latest_artifact: $IMAGE_LATEST_ARTIFACT"
 echo "- image_latest_tag: $IMAGE_LATEST_TAG"
-echo "- image_version_artefact: $IMAGE_VERSION_ARTEFACT"
+echo "- image_version_artifact: $IMAGE_VERSION_ARTIFACT"
 echo "- image_version_tag: $IMAGE_VERSION_TAG"
 echo "- short_sha: $SHORT_SHA"
 echo "- version_slug: $VERSION_SLUG"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "get-deployment-info"
-version = "0.1.2"
+version = "0.1.3"
 description = "A Github Action that gets the information required to build and deploy an Octue service."
 authors = ["Marcus Lugg <marcus@octue.com>"]
 readme = "README.md"


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#7](https://github.com/octue/get-deployment-info/pull/7))

### Fixes
- Rename "artefact" to "artifact" to align with common spelling

<!--- END AUTOGENERATED NOTES --->