### PR TITLE
Remove GCP environment input

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,6 @@ jobs:
           gcp_region: europe-west6
           gcp_resource_affix: my-affix
           gcp_service_name: my-test-service
-          gcp_environment: main
 
       - name: Get short SHA
         id: get-short-sha

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.10.7-slim
 
 RUN apt-get update -y && apt-get install -y --fix-missing curl git && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install git+https://github.com/octue/get-deployment-info@remove-gcp-environment-input
+RUN pip3 install git+https://github.com/octue/get-deployment-info@0.2.3
 
 COPY get_deployment_info/entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.10.7-slim
 
 RUN apt-get update -y && apt-get install -y --fix-missing curl git && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install git+https://github.com/octue/get-deployment-info@0.2.3
+RUN pip3 install git+https://github.com/octue/get-deployment-info@remove-gcp-environment-input
 
 COPY get_deployment_info/entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.10.7-slim
 
 RUN apt-get update -y && apt-get install -y --fix-missing curl git && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install git+https://github.com/octue/get-deployment-info@0.2.3
+RUN pip3 install git+https://github.com/octue/get-deployment-info@0.3.0
 
 COPY get_deployment_info/entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ steps:
 
   - name: Get deployment info
     id: get-deployment-info
-    uses: octue/get-deployment-info@0.2.3
+    uses: octue/get-deployment-info@0.3.0
     with:
       gcp_project_name: test-project
       gcp_project_number: 1234

--- a/action.yaml
+++ b/action.yaml
@@ -20,10 +20,6 @@ inputs:
   gcp_service_name:
     description: "The name of the service being deployed."
     required: true
-  gcp_environment:
-    description: "The environment in Google Cloud the service is being deployed into e.g. 'staging' or 'production'."
-    required: false
-    default: main
 
 outputs:
   branch_tag_kebab:
@@ -58,16 +54,16 @@ outputs:
     description: "A label to affix to the names of the resources created during deployment. This helps avoid confusion about what resources belong to what applications and aids cleanup of old resources."
   gcp_service_name:
     description: "The name of the service being deployed."
-  gcp_environment:
-    description: "The environment in Google Cloud the service is being deployed into e.g. 'staging' or 'production'."
-
+  gcp_environment_kebab:
+    description: "If the branch is 'main', this is 'production'; otherwise it's 'staging'."
+  gcp_environment_screaming:
+    description: "If the branch is 'main', this is 'PRODUCTION'; otherwise it's 'STAGING'."
 runs:
   using: "docker"
-  image: "docker://octue/get-deployment-info:0.2.3"
+  image: "docker://octue/get-deployment-info:0.3.0"
   args:
     - ${{ inputs.gcp_project_name }}
     - ${{ inputs.gcp_project_number }}
     - ${{ inputs.gcp_region }}
     - ${{ inputs.gcp_resource_affix }}
     - ${{ inputs.gcp_service_name }}
-    - ${{ inputs.gcp_environment }}

--- a/get_deployment_info/entrypoint.sh
+++ b/get_deployment_info/entrypoint.sh
@@ -5,7 +5,6 @@ GCP_PROJECT_NUMBER=$2
 GCP_REGION=$3
 GCP_RESOURCE_AFFIX=$4
 GCP_SERVICE_NAME=$5
-GCP_ENVIRONMENT=$6
 
 # Get package version.
 if [ -f "pyproject.toml" ]; then VERSION=$(poetry version -s); \
@@ -23,7 +22,6 @@ echo "gcp_project_number=$GCP_PROJECT_NUMBER" >> $GITHUB_OUTPUT
 echo "gcp_region=$GCP_REGION" >> $GITHUB_OUTPUT
 echo "gcp_resource_affix=$GCP_RESOURCE_AFFIX" >> $GITHUB_OUTPUT
 echo "gcp_service_name=$GCP_SERVICE_NAME" >> $GITHUB_OUTPUT
-echo "gcp_environment=$GCP_ENVIRONMENT" >> $GITHUB_OUTPUT
 
 # Get slugified branch name, resource names, and docker image tags.
 SHORT_SHA="$(git config --global --add safe.directory /github/workspace && git rev-parse --short HEAD)"
@@ -39,10 +37,14 @@ if [ "$BRANCH_TAG_KEBAB" = "main" ]; then
   REVISION_TAG=$VERSION
   IMAGE_VERSION_TAG="$BRANCH_TAG_KEBAB-$REVISION_TAG"
   IMAGE_LATEST_TAG="$BRANCH_TAG_KEBAB-latest"
+  GCP_ENVIRONMENT=production >> $GITHUB_OUTPUT
+  GCP_ENVIRONMENT_SCREAMING=PRODUCTION >> $GITHUB_OUTPUT
 else
   REVISION_TAG=$(expr substr "$BRANCH_TAG_KEBAB" 1 12)
   IMAGE_VERSION_TAG="$REVISION_TAG"
   IMAGE_LATEST_TAG="$REVISION_TAG-latest"
+  GCP_ENVIRONMENT_KEBAB=staging >> $GITHUB_OUTPUT
+  GCP_ENVIRONMENT_SCREAMING=STAGING >> $GITHUB_OUTPUT
 fi
 
 echo "revision_tag=$REVISION_TAG" >> $GITHUB_OUTPUT
@@ -58,6 +60,7 @@ echo "image_version_artifact=$IMAGE_VERSION_ARTIFACT" >> $GITHUB_OUTPUT
 
 IMAGE_LATEST_ARTIFACT="$GCP_REGION-docker.pkg.dev/$GCP_PROJECT_NAME/$GCP_RESOURCE_AFFIX/$GCP_SERVICE_NAME:$IMAGE_LATEST_TAG"
 echo "image_latest_artifact=$IMAGE_LATEST_ARTIFACT" >> $GITHUB_OUTPUT
+
 
 # Echo the outputs to stdout to aid debugging.
 echo ""
@@ -79,4 +82,5 @@ echo "- gcp_project_number: $GCP_PROJECT_NUMBER"
 echo "- gcp_region: $GCP_REGION"
 echo "- gcp_resource_affix: $GCP_RESOURCE_AFFIX"
 echo "- gcp_service_name: $GCP_SERVICE_NAME"
-echo "- gcp_environment: $GCP_ENVIRONMENT"
+echo "- gcp_environment_kebab: $GCP_ENVIRONMENT_KEBAB"
+echo "- gcp_environment_screaming: $GCP_ENVIRONMENT_SCREAMING"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "get-deployment-info"
-version = "0.2.3"
+version = "0.3.0"
 description = "A Github Action that gets the information required to build and deploy an Octue service."
 authors = ["Marcus Lugg <marcus@octue.com>"]
 readme = "README.md"


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
# Contents ([#16](https://github.com/octue/get-deployment-info/pull/16))

**IMPORTANT:** There is 1 breaking change.

### New features
- 💥 **BREAKING CHANGE:** Deduce GCP environment from branch name. It will be `production` for `main` branch and `staging` for other branches

---
# Upgrade instructions
<details>
<summary>💥 <b>Deduce GCP environment from branch name</b></summary>

Stop using the `gcp_environment` input and use the `gcp_environment_kebab` and/or `gcp_environment_screaming` outputs.
</details>

<!--- END AUTOGENERATED NOTES --->